### PR TITLE
backwards compatible fix for breaking changes introduced in 0.12.1

### DIFF
--- a/lib/exmsgpack.ex
+++ b/lib/exmsgpack.ex
@@ -43,7 +43,8 @@ defmodule MsgPack.Match do
     Enum.reduce names,
         pattern, fn(key, pat) ->
           if Enum.count(names, fn(x) -> x == key end) > 1 do
-            replace(key, (quote do: var!(unquote(binary_to_atom("_#{key}")), __MODULE__)), pat)
+            var = { :"_#{key}", [], __MODULE__ }
+            replace(key, var, pat)
           else
             replace(key, (quote do: _), pat)
           end


### PR DESCRIPTION
a change was introduced in Elixir 0.12.1 which broke compilation of
exmsgpack because bitstring modifier args were not being expanded.
This will be fixed in 0.12.2 but this is a backwards compatible patch
that will ensure exmsgpack will work on all previous versions of
Elixir including 0.12.1.

Initial discussion: https://github.com/elixir-lang/elixir/issues/1977
Fix: https://github.com/elixir-lang/elixir/commit/952052869ff7af0e293d2a7160b1aebc68fc46be
