### PR TITLE
Fix protocol implementation for Integers

### DIFF
--- a/lib/exmsgpack.ex
+++ b/lib/exmsgpack.ex
@@ -302,7 +302,7 @@ defprotocol MsgPack.Protocol do
   def pack(term)
 end
 
-defimpl MsgPack.Protocol, for: Number do
+defimpl MsgPack.Protocol, for: Integer do
 
   @spec pack(number) :: MsgPack.packed
   def pack(i) when is_integer(i) and i < 0 do


### PR DESCRIPTION
The protocol implementation for integers should be for `Integer` and not `Number`
